### PR TITLE
Fix snap install by creating directory before copying

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -21,4 +21,7 @@ if [ ! -f "$SNAP_DATA/config/edgex-device-grove/res/configuration.toml" ]; then
         "$SNAP_DATA/config/edgex-device-grove/res/configuration.toml"
 fi
 
-cp "$SNAP/config/edgex-device-grove/res/profiles/Grove_Device.yaml" "$SNAP_DATA/config/edgex-device-grove/res/profiles/Grove_Device.yaml"
+mkdir -p $SNAP_DATA/config/edgex-device-grove/res/profiles
+if [ ! -f "$SNAP_DATA/config/edgex-device-grove/res/profiles/Grove_Device.yaml" ]; then
+    cp "$SNAP/config/edgex-device-grove/res/profiles/Grove_Device.yaml" "$SNAP_DATA/config/edgex-device-grove/res/profiles/Grove_Device.yaml"
+fi


### PR DESCRIPTION
Previously the snap was uninstallable because the directory didn't exist.

for example:

```
$ snap install edgex-device-grove_1.0.1-20190706+4d03f64_amd64.snap --dangerous 
error: cannot perform the following tasks:
- Run install hook of "edgex-device-grove" snap if present (run hook "install": cp: cannot create regular file '/var/snap/edgex-device-grove/x1/config/edgex-device-grove/res/profiles/Grove_Device.yaml': No such file or directory)
```