### PR TITLE
snapcraft.yaml: specify ProfilesDir in the config file as $SNAP_DATA/.../profiles

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,7 @@ parts:
         -e s'@Host = \"edgex-device-grove\"@Host = \"localhost\"@' \
         -e s'@Host = \"edgex-core-data\"@Host = \"localhost\"@' \
         -e s'@Host = \"edgex-core-metadata\"@Host = \"localhost\"@' \
+        -e s'@ProfilesDir = \"\"@ProfilesDir = \"\$SNAP_DATA/config/edgex-device-grove/res/profiles\"@' \
         $SNAPCRAFT_PART_INSTALL/res/configuration.toml
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/doc/edgex-device-grove
       mkdir -p $SNAPCRAFT_PART_INSTALL/config


### PR DESCRIPTION
This will enable automatic import of the device profile copied into $SNAP_DATA
by the install hook.

Fixes #19 for master/fuji