### PR TITLE
build: fix VERSION copy after removal from repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ test:
 clean:
 	    rm -f $(MICROSERVICES)
 
+version:
+	    echo -n ${VERSION}
+
 docker: $(DOCKERS)
 
 docker_device_grove_c:

--- a/scripts/Dockerfile.alpine-3.11
+++ b/scripts/Dockerfile.alpine-3.11
@@ -5,14 +5,15 @@ RUN apk add --update --no-cache build-base git gcc cmake make linux-headers yaml
 
 COPY scripts /device-grove/scripts
 COPY src /device-grove/src/
-COPY VERSION /device-grove
+COPY Makefile /device-grove/Makefile
+RUN cd /device-grove && make -s version | tee /device-grove/VERSION && rm -f /device-grove/Makefile
 RUN mkdir -p /device-grove/build
 
 WORKDIR /device-grove
 RUN /device-grove/scripts/build_deps.sh 1
 RUN /device-grove/scripts/build.sh
 
-FROM alpine:3.9
+FROM alpine:3.11
 
 RUN apk add --update --no-cache linux-headers yaml libmicrohttpd curl libuuid
 

--- a/scripts/Dockerfile.alpine-3.11-base
+++ b/scripts/Dockerfile.alpine-3.11-base
@@ -5,7 +5,8 @@ RUN apk add --update --no-cache build-base git gcc cmake make linux-headers yaml
 
 COPY scripts /device-grove/scripts
 COPY src /device-grove/src/
-COPY VERSION /device-grove
+COPY Makefile /device-grove/Makefile
+RUN cd /device-grove && make -s version | tee /device-grove/VERSION && rm -f /device-grove/Makefile
 RUN mkdir -p /device-grove/build
 
 WORKDIR /device-grove


### PR DESCRIPTION
After the removal of the `VERSION` file from the repo, the local docker build command started failing. This PR writes the VERSION file on the fly to the docker image using the new `make version` target.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information