### PR TITLE
fix: remove obsolete/inapplicable elements from profiles

### DIFF
--- a/profiles/Grove_Button.yaml
+++ b/profiles/Grove_Button.yaml
@@ -11,7 +11,7 @@ deviceResources:
     { Pin_Num: "D4", Interface: "GPIO", Type: "IN" }
   properties:
     value:
-      { type: "Uint8", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "Uint8", readWrite: "RW", minimum: "0", maximum: "1", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "" }
 

--- a/profiles/Grove_Buzzer.yaml
+++ b/profiles/Grove_Buzzer.yaml
@@ -11,7 +11,7 @@ deviceResources:
     { Pin_Num: "D8", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "Bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "Bool", readWrite: "RW" }
     units:
       { type: "String", readWrite: "R", defaultValue: "on/off" }
 

--- a/profiles/Grove_LCD.yaml
+++ b/profiles/Grove_LCD.yaml
@@ -11,7 +11,7 @@ deviceResources:
     { Pin_Num: "I2C-2", Interface: "I2C", Type: "LCD" }
   properties:
     value:
-      { type: "String", readWrite: "RW", size: "16", minimum: "0", maximum: "15", defaultValue: "0" }
+      { type: "String", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "0" }
 - name: Row
@@ -20,7 +20,7 @@ deviceResources:
     { Pin_Num: "I2C-2", Interface: "I2C", Type: "LCD" }
   properties:
     value:
-      { type: "Uint8", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "Uint8", readWrite: "RW", minimum: "0", maximum: "1", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "0" }
 - name: Column
@@ -29,7 +29,7 @@ deviceResources:
     { Pin_Num: "I2C-2", Interface: "I2C", Type: "LCD" }
   properties:
     value:
-      { type: "Uint8", readWrite: "RW", size: "1", minimum: "0", maximum: "15", defaultValue: "0" }
+      { type: "Uint8", readWrite: "RW", minimum: "0", maximum: "15", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "0" }
 

--- a/profiles/Grove_LED.yaml
+++ b/profiles/Grove_LED.yaml
@@ -11,7 +11,7 @@ deviceResources:
     { Pin_Num: "D3", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "Bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "Bool", readWrite: "RW" }
     units:
       { type: "String", readWrite: "R", defaultValue: "Enabled/Disabled" }
 
@@ -21,7 +21,7 @@ deviceResources:
     { Pin_Num: "D6", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "Bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "Bool", readWrite: "RW"  }
     units:
       { type: "String", readWrite: "R", defaultValue: "Enabled/Disabled" }
 
@@ -31,7 +31,7 @@ deviceResources:
     { Pin_Num: "D2", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "Bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "Bool", readWrite: "RW" }
     units:
       { type: "String", readWrite: "R", defaultValue: "Enabled/Disabled" }
 

--- a/profiles/Grove_LightSensor.yaml
+++ b/profiles/Grove_LightSensor.yaml
@@ -11,7 +11,7 @@ deviceResources:
     { Pin_Num: "A0", Interface: "AIO", Type: "IN" }
   properties:
     value:
-      { type: "Float32", readWrite: "RW", minimum: "0", maximum: "", defaultValue: "0" }
+      { type: "Float32", readWrite: "RW", minimum: "0", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "lumen" }
 

--- a/profiles/Grove_Relay.yaml
+++ b/profiles/Grove_Relay.yaml
@@ -11,7 +11,7 @@ deviceResources:
     { Pin_Num: "D7", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "Bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "Bool", readWrite: "RW" }
     units:
       { type: "String", readWrite: "R", defaultValue: "on/off" }
 

--- a/res/Grove_Device.yaml
+++ b/res/Grove_Device.yaml
@@ -12,7 +12,7 @@ deviceResources:
     { Pin_Num: "D2", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "bool", readWrite: "RW" }
     units:
       { type: "string", readWrite: "R", defaultValue: "Enabled/Disabled" }
 - name: Green-LED
@@ -21,7 +21,7 @@ deviceResources:
     { Pin_Num: "D3", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "bool", readWrite: "RW" }
     units:
       { type: "string", readWrite: "R", defaultValue: "Enabled/Disabled" }
 - name: ButtonState
@@ -30,7 +30,7 @@ deviceResources:
     { Pin_Num: "D4", Interface: "GPIO", Type: "IN" }
   properties:
     value:
-      { type: "uint8", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "uint8", readWrite: "RW", minimum: "0", maximum: "1", defaultValue: "0" }
     units:
       { type: "string", readWrite: "R", defaultValue: " " }
 - name: Red-LED
@@ -39,7 +39,7 @@ deviceResources:
     { Pin_Num: "D6", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "bool", readWrite: "RW" }
     units:
       { type: "string", readWrite: "R", defaultValue: "Enabled/Disabled" }
 - name: Grove-Relay
@@ -48,7 +48,7 @@ deviceResources:
     { Pin_Num: "D7", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "bool", readWrite: "RW" }
     units:
       { type: "string", readWrite: "R", defaultValue: " " }
 - name: Grove-Buzzer
@@ -57,7 +57,7 @@ deviceResources:
     { Pin_Num: "D8", Interface: "GPIO", Type: "OUT" }
   properties:
     value:
-      { type: "bool", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "bool", readWrite: "RW" }
     units:
       { type: "string", readWrite: "R", defaultValue: " " }
 - name: Display-String
@@ -66,7 +66,7 @@ deviceResources:
     { Pin_Num: "I2C-2", Interface: "I2C", Type: "LCD" }
   properties:
     value:
-      { type: "string", readWrite: "RW", size: "16", minimum: "0", maximum: "15", defaultValue: "0" }
+      { type: "string", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "string", readWrite: "R", defaultValue: "0" }
 - name: Row
@@ -75,7 +75,7 @@ deviceResources:
     { Pin_Num: "I2C-2", Interface: "I2C", Type: "LCD" }
   properties:
     value:
-      { type: "uint8", readWrite: "RW", size: "1", minimum: "0", maximum: "1", defaultValue: "0" }
+      { type: "uint8", readWrite: "RW", minimum: "0", maximum: "1", defaultValue: "0" }
     units:
       { type: "string", readWrite: "R", defaultValue: "0" }
 - name: Column
@@ -84,7 +84,7 @@ deviceResources:
     { Pin_Num: "I2C-2", Interface: "I2C", Type: "LCD" }
   properties:
     value:
-      { type: "uint8", readWrite: "RW", size: "1", minimum: "0", maximum: "15", defaultValue: "0" }
+      { type: "uint8", readWrite: "RW", minimum: "0", maximum: "15", defaultValue: "0" }
     units:
       { type: "string", readWrite: "R", defaultValue: "0" }
 - name: LightIntensity
@@ -93,7 +93,7 @@ deviceResources:
     { Pin_Num: "A0", Interface: "AIO", Type: "IN" }
   properties:
     value:
-      { type: "float32", floatEncoding: "eNotation", readWrite: "RW", minimum: "0", maximum: "", defaultValue: "0" }
+      { type: "float32", floatEncoding: "eNotation", readWrite: "RW", minimum: "0", defaultValue: "0" }
     units:
       { type: "string", readWrite: "R", defaultValue: "lumen" }
 - name: SoundIntensity

--- a/res/configuration.toml
+++ b/res/configuration.toml
@@ -26,7 +26,6 @@
   MaxCmdResultLen = 256
   RemoveCmd = ""
   RemoveCmdArgs = ""
-  ProfilesDir = ""
   SendReadingsOnChanged = true
 
 [Driver]


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-grove-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Profiles contain inapplicable elements which are rejected by the SDK

## Issue Number:


## What is the new behavior?
Removed obsolete and inapplicable elements from profiles

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
