### PR TITLE
fix: use new port assignments (#65), standardise service name (#66)

### DIFF
--- a/res/configuration.toml
+++ b/res/configuration.toml
@@ -1,7 +1,7 @@
 [Service]
   Host = "edgex-device-grove"
   ServerBindAddr = '0.0.0.0'
-  Port = 49992
+  Port = 59992
   ConnectRetries = 3
   HealthCheck = ""
   StartupMsg = "device Grove PI started"
@@ -12,11 +12,11 @@
 [Clients]
   [Clients.Data]
     Host = "edgex-core-data"
-    Port = 48080
+    Port = 59880
 
   [Clients.Metadata]
     Host = "edgex-core-metadata"
-    Port = 48081
+    Port = 59881
 
 [Device]
   DataTransform = true

--- a/src/c/device_grove.h
+++ b/src/c/device_grove.h
@@ -35,7 +35,7 @@ extern "C" {
 #define GROVE_ROTARY_MAX_ANGLE 300
 #define GROVE_ADC_REF 5
 
-#define GROVE_SVC "Device-Grove"
+#define GROVE_SVC "device-grove"
 
 typedef enum
 {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-grove-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
1) Service uses old port assignments (48xxx, 49xxx)
2) Default service name is mixed-case

## Issue Number: #65  #66 


## What is the new behavior?
New port assignments  (598xx, 599xx)
Service name is `device-grove`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

Reconfiguration required for clients using old port numbers
## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->
Scripting in `test/` directory still harbors old port numbers; however this needs to be reworked in any case as export-client is no longer supported

## Other information
