### PR TITLE
build(snap): update versioning to use git tag

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,14 +35,11 @@ parts:
     source: snap/local
     override-pull: |
       cd $SNAPCRAFT_PROJECT_DIR
-      if [ -f VERSION ]; then
-        PROJECT_VERSION=$(cat VERSION)
-      else
-        PROJECT_VERSION="0.0.0"
-        # The cmake build requires a VERSION file
-        echo $PROJECT_VERSION > VERSION
+      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      if [ -z "$GIT_VERSION" ]; then
+        GIT_VERSION="0.0.0"
       fi
-      snapcraftctl set-version ${PROJECT_VERSION}
+      snapcraftctl set-version ${GIT_VERSION}
   config:
     source: .
     plugin: dump
@@ -151,6 +148,10 @@ parts:
   edgex-device-grove:
     source: .
     plugin: cmake
+    override-pull: |
+      snapcraftctl pull
+      cd $SNAPCRAFT_PROJECT_DIR
+      make version
     source-subdir: src/c
     after: 
       - device-sdk-c


### PR DESCRIPTION
This commit updates the snap to set the snap version to the latest git tag version.
It also creates a VERSION file for the cmake build to use.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-grove-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
